### PR TITLE
Upgrade react-hook-form

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "react": "^16.13.1",
     "react-docgen-typescript-loader": "^3.7.2",
     "react-dom": "^16.13.1",
-    "react-hook-form": "6.11.4",
+    "react-hook-form": "^6.11.4",
     "react-is": "^16.13.1",
     "react-select": "^3.1.0",
     "ts-loader": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
     "build-storybook": "build-storybook -c .storybook -o docs"
   },
   "peerDependencies": {
+    "@chakra-ui/core": "^0.7.0",
     "react": ">=16",
-    "react-hook-form": "^5.4.2",
-    "@chakra-ui/core": "^0.7.0"
+    "react-hook-form": ">=6"
   },
   "homepage": "https://github.com/FionnCasey/react-hook-form-generator#readme",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "react": "^16.13.1",
     "react-docgen-typescript-loader": "^3.7.2",
     "react-dom": "^16.13.1",
-    "react-hook-form": "^5.4.2",
+    "react-hook-form": "6.11.4",
     "react-is": "^16.13.1",
     "react-select": "^3.1.0",
     "ts-loader": "^7.0.0",

--- a/src/components/CheckboxField.tsx
+++ b/src/components/CheckboxField.tsx
@@ -29,7 +29,7 @@ export const CheckboxField: FC<FieldProps<CheckboxFieldSchema>> = ({
 
   const { register, watch } = useFormContext();
 
-  const values = watch({ nest: true });
+  const values = watch();
 
   const fieldStyles = useStyles<CheckboxFieldStyles>('checkboxField', styles);
 

--- a/src/components/Containers.tsx
+++ b/src/components/Containers.tsx
@@ -157,7 +157,7 @@ export const ArrayField: FC<FieldProps<ArrayFieldSchema>> = ({
 
   const { control, watch } = useFormContext();
 
-  const values = watch({ nest: true });
+  const values = watch();
 
   const { fields, append, remove } = useFieldArray({ name, control });
 
@@ -286,7 +286,7 @@ export const ObjectField: FC<FieldProps<ObjectFieldSchema>> = ({
 
   const { watch } = useFormContext();
 
-  const values = watch({ nest: true });
+  const values = watch();
 
   const { isOpen, onToggle } = useDisclosure(true);
 

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -1,6 +1,6 @@
 import React, { FC, BaseSyntheticEvent, useMemo } from 'react';
 import { Box, Heading, Stack, ButtonGroup, Button } from '@chakra-ui/core';
-import { useForm, FormContext, UseFormOptions } from 'react-hook-form';
+import { useForm, FormProvider, UseFormOptions } from 'react-hook-form';
 import merge from 'lodash.merge';
 
 import { FormStyles, Field, Schema } from '../types';
@@ -133,7 +133,7 @@ export const Form: FC<FormProps> = ({
 
   return (
     <StyleCtx.Provider value={baseStyles}>
-      <FormContext {...form}>
+      <FormProvider {...form}>
         <Box
           as="form"
           onSubmit={form.handleSubmit(handleSubmit)}
@@ -154,7 +154,7 @@ export const Form: FC<FormProps> = ({
             </Button>
           </ButtonGroup>
         </Box>
-      </FormContext>
+      </FormProvider>
     </StyleCtx.Provider>
   );
 };

--- a/src/components/NumberField.tsx
+++ b/src/components/NumberField.tsx
@@ -34,7 +34,7 @@ export const NumberField: FC<FieldProps<NumberFieldSchema>> = ({
 
   const { control, watch } = useFormContext();
 
-  const values = watch({ nest: true });
+  const values = watch();
 
   const errorMessage = useErrorMessage(name, label);
 

--- a/src/components/SelectField.tsx
+++ b/src/components/SelectField.tsx
@@ -21,7 +21,7 @@ export const SelectField: FC<FieldProps<SelectFieldSchema>> = ({
 
   const { register, watch } = useFormContext();
 
-  const values = watch({ nest: true });
+  const values = watch();
 
   const fieldStyles = useStyles<SelectFieldStyles>('selectField', styles);
 

--- a/src/components/SwitchField.tsx
+++ b/src/components/SwitchField.tsx
@@ -21,7 +21,7 @@ export const SwitchField: FC<FieldProps<SwitchFieldSchema>> = ({
 
   const { register, watch } = useFormContext();
 
-  const values = watch({ nest: true });
+  const values = watch();
 
   const fieldStyles = useStyles<SwitchFieldStyles>('switchField', styles);
 

--- a/src/components/TextAreaField.tsx
+++ b/src/components/TextAreaField.tsx
@@ -32,7 +32,7 @@ export const TextAreaField: FC<FieldProps<TextAreaFieldSchema>> = ({
 
   const errorMessage = useErrorMessage(name, label);
 
-  const values = watch({ nest: true });
+  const values = watch();
 
   const isVisible = useMemo(() => {
     return shouldDisplay ? shouldDisplay(values) : true;

--- a/src/components/TextField.tsx
+++ b/src/components/TextField.tsx
@@ -38,7 +38,7 @@ export const TextField: FC<FieldProps<TextFieldSchema>> = ({
 
   const errorMessage = useErrorMessage(name, label);
 
-  const values = watch({ nest: true });
+  const values = watch();
 
   const isVisible = useMemo(() => {
     return shouldDisplay ? shouldDisplay(values) : true;

--- a/src/types.ts
+++ b/src/types.ts
@@ -152,7 +152,7 @@ export interface FieldStyles {
   input?: InputProps<HTMLInputElement>;
   helperText?: BoxProps;
   errorMessage?: BoxProps;
-  inputGroup?: Omit<InputGroupProps, 'children'>
+  inputGroup?: Omit<InputGroupProps, 'children'>;
 }
 
 export interface ArrayFieldStyles

--- a/yarn.lock
+++ b/yarn.lock
@@ -8722,9 +8722,10 @@ react-helmet-async@^1.0.2:
     react-fast-compare "^3.0.1"
     shallowequal "^1.1.0"
 
-react-hook-form@^5.4.2:
-  version "5.7.2"
-  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-5.7.2.tgz#a84e259e5d37dd30949af4f79c4dac31101b79ac"
+react-hook-form@6.11.4:
+  version "6.11.4"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-6.11.4.tgz#726036d33ac8cff8d88c881f6ca96e85795c43ec"
+  integrity sha512-jIcXczV7Qp2Br4+e1hI99V1WqM+wB/6YlZ/oVQ5OPKeTTpal1sDClMLa7456+kAyRkeZJWj9XwqElio0OfHUWA==
 
 react-hotkeys@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This is a PR to [upgrade `react-hook-form`](https://react-hook-form.com/migrate-v5-to-v6/) from `^5.4.2` to `^6.11.4`